### PR TITLE
Add styles to advertise the community survey

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bit-docs-html-toc": "^0.5.0"
   },
   "dependencies": {
+    "donejs-survey-ad": "^0.1.1",
     "jquery": "^3.1.1"
   }
 }

--- a/static/docjs.js
+++ b/static/docjs.js
@@ -1,4 +1,5 @@
 var $ = require("jquery");
+var SurveyAdControl = require("donejs-survey-ad");
 
 require("./styles/styles.less");
 require("./styles/github-v2.css");
@@ -75,4 +76,13 @@ $(function() {
 			'</a>'
 		);
 	}
+
+	// Set up the survey ad control
+	var footerElement = document.body.querySelector('footer');
+	var surveyAdControl = new SurveyAdControl("survey-ad", {
+		addShowingClassToElement: footerElement
+	});
+	// Notify the survey ad control that the user loaded a page
+	surveyAdControl.didEngage();
+
 });

--- a/static/styles/layout.less
+++ b/static/styles/layout.less
@@ -9,7 +9,7 @@ header {
 	color: #fff;
 	position: relative;
 	z-index: 2;
-	
+
 	.container {
 		position: relative;
 		height: @headerHeight;
@@ -27,7 +27,7 @@ header {
 		display: inline-block;
 		line-height: @headerHeight;
 		position: relative;
-		
+
 		> a {
 			text-transform: uppercase;
 			text-decoration: none;
@@ -58,7 +58,7 @@ header {
 			border-bottom-style: none;
 		}
 	}
-	
+
 	.nav > li:hover > a {
 		background-color: rgba(0, 0, 0, 0.1);
 		border: 1px solid rgba(0, 0, 0, 0.3);
@@ -79,7 +79,7 @@ header {
 		text-align: center;
 		width: 50px;
 		height: 54px;
-		
+
 		&:before {
 			/*
 			right: 4px;
@@ -115,7 +115,7 @@ header {
 		list-style-type: none;
 		top: @headerHeight;
 		width: 240px;
-		
+
 		li a {
 			display: block;
 			text-decoration: none;
@@ -165,15 +165,20 @@ footer {
 	padding-bottom: 0px;
 	position: relative;
 	text-align: right;
+	transition: padding-bottom .25s ease;
 	height:  @footerHeight;
-	
+
+	&.survey-ad-showing {
+		padding-bottom: 3rem;
+	}
+
 	.container {
 		text-align: right;
 		position: relative;
 		height:  @footerHeight;
 		overflow: hidden;
 	}
-	
+
 	li a {
 		font-size: 12px;
 		font-weight: bold;

--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -11,6 +11,7 @@
 @import 'guides.less';
 @import 'ie.less';
 @import 'highlight.less';
+@import 'survey-ad.less';
 
 .search-wrapper {
 	position:relative;

--- a/static/styles/survey-ad.less
+++ b/static/styles/survey-ad.less
@@ -1,0 +1,21 @@
+survey-ad {
+  border-top: 1px solid #d5d5d5;
+
+  a {
+    color: inherit;
+    line-height: 2rem;
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+
+  .close {
+    color: @brand-color-1;
+    line-height: 2rem;
+    width: 2rem;
+  }
+  .close:hover {
+    background-color: transparent;
+  }
+}

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -116,5 +116,4 @@
 </div>
 {{/unless}}
 
-
-
+{{> survey-ad.mustache}}

--- a/templates/survey-ad.mustache
+++ b/templates/survey-ad.mustache
@@ -1,0 +1,8 @@
+<survey-ad>
+  <button aria-label="Close" class="close" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <a href="https://donejs.com/survey.html" target="_blank">
+    Help us improve StealJS by taking our community survey
+  </a>
+</survey-ad>


### PR DESCRIPTION
Similar to how the survey ad works on canjs.com, the control shows up at the bottom of the viewport after the user has visited three pages (ever). There’s an X button to close it, but otherwise the entire bar is a link to the survey landing page.

<img width="1056" alt="screen shot 2017-09-24 at 6 03 01 pm" src="https://user-images.githubusercontent.com/10070176/30819107-8ac0fb74-a1d2-11e7-8c43-d8dccbb61a36.png">
